### PR TITLE
Added finishAll() that resolves when the queue becomes empty.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # JavaScript Semaphore
 
-A promise-based semaphore implementation suitable to be used with async/await.
+A promise-based semaphore implementation suitable to be used with async/await. (This fork includes a function to wait for all queued promises to finish.)
 
 ## Spare me the details, all I need is a lock.
 Just ```import { Lock } from 'semaphore-async-await'```, acquire the lock by calling ```await lock.acquire()``` and release it when you're done by calling ```lock.release()```.

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ import Semaphore from 'semaphore-async-await';
   });
 
   // Wait for everything to finish
-  await wait(2000);
+  await lock.finishAll();
 
   console.log(globalVar === 3);
 })();

--- a/__tests__/Semaphore.spec.ts
+++ b/__tests__/Semaphore.spec.ts
@@ -168,4 +168,22 @@ describe('Semaphore', () => {
 
     expect(global).toEqual(2);
   });
+
+  it('using finishAll', async () => {
+    let global = 0;
+    const lock = new Semaphore(1);
+
+    const f = async () => {
+      await lock.wait();
+      const local = global;
+      await wait(500);
+      global = local + 1;
+      lock.signal();
+    };
+
+    f(); f(); f(); f();
+    await lock.finishAll();
+
+    expect(global).toEqual(4);
+  });
 });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "semaphore-async-await",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "author": {
     "name": "Jan Soendermann",
     "email": "jan.soendermann+npm@gmail.com"

--- a/package.json
+++ b/package.json
@@ -1,14 +1,20 @@
 {
-  "name": "semaphore-async-await",
+  "name": "@gombosg/semaphore-async-await",
   "version": "1.5.2",
   "author": {
     "name": "Jan Soendermann",
     "email": "jan.soendermann+npm@gmail.com"
   },
-  "homepage": "https://github.com/jsoendermann/semaphore-async-await",
+  "contributors": [
+    {
+      "name": "Gergely Gombos",
+      "email": "gombosg+npm@gmail.com"
+    }
+  ],
+  "homepage": "https://github.com/gombosg/semaphore-async-await",
   "repository": {
     "type": "git",
-    "url": "git@github.com:jsoendermann/semaphore-async-await.git"
+    "url": "git@github.com:gombosg/semaphore-async-await.git"
   },
   "license": "MIT",
   "scripts": {


### PR DESCRIPTION
Hi,

We used the semaphore for some filesystem/SQL/AWS connections and liked its simplicity. Now, a more complicated connection pool could be used but I like the simplicity of this library.

We wanted an extra method to wait for all of the connections to finish when e.g. ending the program. So I added it. It's my first PR on GitHub, as a junior dev, so please treat accordingly, feel free to rename and move stuff etc.

It's non-blocking waiting, stores a promise and its resolver in the object. Returns the promise when needed, and tries to resolve it after each permit release.

A future development could be 

- a finishAllWithin(time) method, that resolves false if the queue does not empty within the given time - so that e.g. errors can be thrown in the main program.
- creating a getter for maxPermits if someone ever needs to check up on that property.

These methods of course have to be used responsibly, but they could be very useful in some scripts.

Best regards,
Greg