### PR TITLE
Add getPromiseResolverQueueLength method

### DIFF
--- a/__tests__/Semaphore.spec.ts
+++ b/__tests__/Semaphore.spec.ts
@@ -168,4 +168,33 @@ describe('Semaphore', () => {
 
     expect(global).toEqual(2);
   });
+
+  it('using getPromiseResolverQueueLength successfully', async () => {
+    const lock = new Semaphore(1);
+
+    const f = async (expectedQueueLength: number) => {
+      const waitingFunctions = lock.getPromiseResolverQueueLength();
+      expect(waitingFunctions).toEqual(expectedQueueLength);
+      await lock.wait();
+      await wait(500);
+      lock.signal();
+    };
+
+    // First function
+    // it's the first function, so no one is in the waitingQueue
+    f(0);
+    wait(10);
+    // Second function
+    // the first function is running, so the expected queueLength is 0
+    f(0);
+    wait(10);
+    // Third function
+    // the second function is still waiting for the lock, so the expected queueLength is 1
+    f(1);
+    wait(10);
+    // Fourth function
+    // the second and the third functions are still waiting for the lock, so the expected queueLength is 2
+    f(2);
+    wait(10);
+  });
 });

--- a/__tests__/Semaphore.spec.ts
+++ b/__tests__/Semaphore.spec.ts
@@ -185,15 +185,15 @@ describe('Semaphore', () => {
     f(0);
     wait(10);
     // Second function
-    // the first function is running, so the expected queueLength is 0
+    // the first function is running, so the expected waitingQueue length is still 0
     f(0);
     wait(10);
     // Third function
-    // the second function is still waiting for the lock, so the expected queueLength is 1
+    // the second function is still waiting for the lock, so the expected waitingQueue length is 1
     f(1);
     wait(10);
     // Fourth function
-    // the second and the third functions are still waiting for the lock, so the expected queueLength is 2
+    // the second and the third functions are still waiting for the lock, so the expected waitingQueue length is 2
     f(2);
     wait(10);
   });

--- a/src/Semaphore.ts
+++ b/src/Semaphore.ts
@@ -33,6 +33,14 @@ export default class Semaphore {
   }
 
   /**
+   * Returns the number of functions currently waiting for the lock.
+   * @returns  The number of waiting functions.
+   */
+  public getPromiseResolverQueueLength(): number {
+    return this.promiseResolverQueue.length;
+  }
+
+  /**
    * Returns a promise used to wait for a permit to become available. This method should be awaited on.
    * @returns  A promise that gets resolved when execution is allowed to proceed.
    */


### PR DESCRIPTION
Hi,

We use this library for some Session Cache management stuff, really liked its simplicity.

We would like to add an extra method which enables us access the number of the requests that are currently waiting for the lock 
(so basically have access to the private `promiseResolverQueue` field of the Semaphore).

With this method we can implement behaviors like this:

```
 // Get how many requests are waiting on this lock
    currentWaitQueueLength = lock.getPromiseResolverQueueLength();
    if (currentWaitQueueLength >= maxWaitQueueLength) {
        // throw error            
	}

// Wait till the lock can be acquired
    await lock.acquire();

// do stuff

// Done - Release the lock and delete it from the locks map if no one needs it

    waitQueueLength = lock.getPromiseResolverQueueLength();
	lock.release();

	if (waitQueueLength === 0) {
        locksMap.delete(sessionId);
    }
```

so basically we can limit the number of requests waiting for a specific lock and we can delete the same lock when no one needs it.
It would be really useful for us, let me know what do you think about it.

Best regards,

Silvia